### PR TITLE
fix: use GITHUB_TOKEN for submodule tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.RELEASE_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Tag submodules
       run: |


### PR DESCRIPTION
## Summary
- Fix release workflow failing because `RELEASE_TOKEN` secret is not configured
- Use `GITHUB_TOKEN` instead, which has `contents: write` permission from the workflow-level permissions

## Test plan
- [ ] Release workflow succeeds on next tag push