### PR TITLE
feat: streaming with tools support (Phase 4 of #13)

### DIFF
--- a/api.go
+++ b/api.go
@@ -65,6 +65,17 @@ type ToolProvider interface {
 	CallWithTools(ctx context.Context, messages []Message, temperature float32, tools []Tool) (*ProviderResponse, error)
 }
 
+// ToolStreamingProvider is an optional interface for providers that support
+// streaming with tool use. Providers that implement this deliver typed events
+// (text chunks, tool call starts/deltas/ends) via StreamEventCallback while
+// executing a tool-enabled request.
+//
+// The returned ProviderResponse contains the full assembled content, tool calls,
+// and usage stats after streaming completes.
+type ToolStreamingProvider interface {
+	StreamWithTools(ctx context.Context, messages []Message, temperature float32, tools []Tool, callback StreamEventCallback) (*ProviderResponse, error)
+}
+
 // Validator defines the interface for response validation.
 // All response types must implement this to ensure LLM outputs are valid.
 type Validator interface {
@@ -143,8 +154,9 @@ type SynapseRequest struct {
 	// Input fields
 	Prompt         *Prompt        // The structured prompt to send to LLM
 	Temperature    float32        // Temperature parameter for response generation
-	StreamCallback StreamCallback // Receives streamed chunks during provider execution. Nil for non-streaming.
-	Tools          []Tool         // Tool definitions for the provider. Nil for non-tool calls.
+	StreamCallback      StreamCallback      // Receives streamed text chunks. Nil for non-streaming.
+	StreamEventCallback StreamEventCallback // Receives typed stream events (text + tool). Nil for non-event-streaming.
+	Tools               []Tool              // Tool definitions for the provider. Nil for non-tool calls.
 
 	// Session fields
 	SessionID string    // ID of the conversation session

--- a/api_test.go
+++ b/api_test.go
@@ -321,4 +321,34 @@ func TestSynapseRequest_ToolsField(t *testing.T) {
 			t.Errorf("expected tool name 'search', got '%s'", req.Tools[0].Name)
 		}
 	})
+
+	t.Run("stream_event_callback_field", func(t *testing.T) {
+		req := SynapseRequest{}
+		if req.StreamEventCallback != nil {
+			t.Error("zero-value SynapseRequest should have nil StreamEventCallback")
+		}
+	})
+}
+
+func TestToolStreamingProvider(t *testing.T) {
+	t.Run("simple", func(_ *testing.T) {
+		var _ ToolStreamingProvider = NewMockToolStreamingProvider()
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Regular MockToolProvider does NOT implement ToolStreamingProvider
+		var provider ToolProvider = NewMockToolProvider()
+		_, ok := provider.(ToolStreamingProvider)
+		if ok {
+			t.Error("MockToolProvider should not implement ToolStreamingProvider")
+		}
+	})
+
+	t.Run("chaining", func(_ *testing.T) {
+		// MockToolStreamingProvider also satisfies ToolProvider and Provider
+		p := NewMockToolStreamingProvider()
+		var _ Provider = p
+		var _ ToolProvider = p
+		var _ ToolStreamingProvider = p
+	})
 }

--- a/mock.go
+++ b/mock.go
@@ -479,3 +479,74 @@ func (m *MockToolProvider) CallWithTools(_ context.Context, messages []Message, 
 		Usage: TokenUsage{Prompt: 100, Completion: 50, Total: 150},
 	}, nil
 }
+
+// MockToolStreamingProvider simulates streaming with tool use by emitting
+// StreamEvents for both text and tool calls. It implements Provider (via embedding),
+// ToolProvider (via MockToolProvider), and ToolStreamingProvider.
+type MockToolStreamingProvider struct {
+	MockToolProvider
+}
+
+// NewMockToolStreamingProvider creates a mock that simulates streaming with tools.
+func NewMockToolStreamingProvider() *MockToolStreamingProvider {
+	return &MockToolStreamingProvider{
+		MockToolProvider: MockToolProvider{
+			MockProvider: MockProvider{
+				name:      "mock-tool-streaming",
+				available: true,
+			},
+		},
+	}
+}
+
+// StreamWithTools simulates streaming a tool-using response by emitting events
+// for each piece of the response, then returning the full assembled result.
+func (m *MockToolStreamingProvider) StreamWithTools(ctx context.Context, messages []Message, temperature float32, tools []Tool, callback StreamEventCallback) (*ProviderResponse, error) {
+	// Get the full response using the non-streaming tool path
+	resp, err := m.CallWithTools(ctx, messages, temperature, tools)
+	if err != nil {
+		return nil, err
+	}
+
+	if callback == nil {
+		return resp, nil
+	}
+
+	// Emit text content as a text event
+	if resp.Content != "" {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			callback(StreamEvent{Type: StreamEventText, Text: resp.Content})
+		}
+	}
+
+	// Emit tool calls as start/end events
+	for i, tc := range resp.ToolCalls {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			tcCopy := tc
+			callback(StreamEvent{
+				Type:     StreamEventToolStart,
+				ToolCall: &tcCopy,
+				Index:    i,
+			})
+			if len(tc.Input) > 0 {
+				callback(StreamEvent{
+					Type:      StreamEventToolDelta,
+					ToolDelta: string(tc.Input),
+					Index:     i,
+				})
+			}
+			callback(StreamEvent{
+				Type:  StreamEventToolEnd,
+				Index: i,
+			})
+		}
+	}
+
+	return resp, nil
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -740,6 +740,78 @@ func TestMockToolProvider_Unavailable(t *testing.T) {
 	}
 }
 
+func TestNewMockToolStreamingProvider(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		provider := NewMockToolStreamingProvider()
+		if provider == nil {
+			t.Fatal("NewMockToolStreamingProvider returned nil")
+		}
+		if provider.Name() != "mock-tool-streaming" {
+			t.Errorf("Expected name 'mock-tool-streaming', got '%s'", provider.Name())
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Emits events for tool calls
+		provider := NewMockToolStreamingProvider()
+		var events []StreamEvent
+		callback := func(e StreamEvent) { events = append(events, e) }
+
+		ctx := context.Background()
+		tools := []Tool{{Name: "get_weather"}}
+		resp, err := provider.StreamWithTools(ctx, nil, 0.5, tools, callback)
+		if err != nil {
+			t.Fatalf("StreamWithTools failed: %v", err)
+		}
+		if resp.StopReason != StopReasonToolUse {
+			t.Errorf("Expected StopReason='tool_use', got '%s'", resp.StopReason)
+		}
+		// Should have tool_start, tool_delta (for empty input {}), tool_end
+		hasStart := false
+		hasEnd := false
+		for _, e := range events {
+			if e.Type == StreamEventToolStart {
+				hasStart = true
+			}
+			if e.Type == StreamEventToolEnd {
+				hasEnd = true
+			}
+		}
+		if !hasStart {
+			t.Error("Expected tool_start event")
+		}
+		if !hasEnd {
+			t.Error("Expected tool_end event")
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		// Nil callback — no events, still returns response
+		provider := NewMockToolStreamingProvider()
+		ctx := context.Background()
+		tools := []Tool{{Name: "search"}}
+		resp, err := provider.StreamWithTools(ctx, nil, 0.5, tools, nil)
+		if err != nil {
+			t.Fatalf("StreamWithTools with nil callback failed: %v", err)
+		}
+		if len(resp.ToolCalls) != 1 {
+			t.Errorf("Expected 1 tool call, got %d", len(resp.ToolCalls))
+		}
+	})
+}
+
+func TestMockToolStreamingProvider_ContextCancellation(t *testing.T) {
+	provider := NewMockToolStreamingProvider()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tools := []Tool{{Name: "search"}}
+	_, err := provider.StreamWithTools(ctx, nil, 0.5, tools, func(_ StreamEvent) {})
+	if err == nil {
+		t.Error("Expected context cancellation error")
+	}
+}
+
 func TestMockProviderFixed_Name(t *testing.T) {
 	provider := NewMockProviderWithResponse(`{"test": "value"}`)
 	name := provider.Name()

--- a/mock_test.go
+++ b/mock_test.go
@@ -2,6 +2,7 @@ package zyn
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -800,16 +801,157 @@ func TestNewMockToolStreamingProvider(t *testing.T) {
 	})
 }
 
-func TestMockToolStreamingProvider_ContextCancellation(t *testing.T) {
+func TestMockToolStreamingProvider_ErrorPath(t *testing.T) {
 	provider := NewMockToolStreamingProvider()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	provider.SetAvailable(false)
 
-	tools := []Tool{{Name: "search"}}
-	_, err := provider.StreamWithTools(ctx, nil, 0.5, tools, func(_ StreamEvent) {})
+	var events []StreamEvent
+	_, err := provider.StreamWithTools(context.Background(), nil, 0.5, []Tool{{Name: "test"}}, func(e StreamEvent) {
+		events = append(events, e)
+	})
 	if err == nil {
-		t.Error("Expected context cancellation error")
+		t.Error("Expected error from unavailable provider")
 	}
+	if len(events) != 0 {
+		t.Error("Should not emit events on error")
+	}
+}
+
+func TestMockToolStreamingProvider_TextContent(t *testing.T) {
+	// Custom response with both text and tool calls to cover text emission path
+	provider := NewMockToolStreamingProvider()
+	provider.WithToolResponse(func(_ []Message, _ []Tool) *ProviderResponse {
+		return &ProviderResponse{
+			Content:    "Here is the result",
+			StopReason: StopReasonToolUse,
+			ToolCalls: []ToolCall{
+				{ID: "call_1", Name: "search", Input: json.RawMessage(`{"q":"test"}`)},
+			},
+			Usage: TokenUsage{Prompt: 100, Completion: 50, Total: 150},
+		}
+	})
+
+	var events []StreamEvent
+	callback := func(e StreamEvent) { events = append(events, e) }
+
+	resp, err := provider.StreamWithTools(context.Background(), nil, 0.5, []Tool{{Name: "search"}}, callback)
+	if err != nil {
+		t.Fatalf("StreamWithTools failed: %v", err)
+	}
+	if resp.Content != "Here is the result" {
+		t.Errorf("Expected content 'Here is the result', got '%s'", resp.Content)
+	}
+
+	// Should have text event + tool_start + tool_delta + tool_end
+	hasText := false
+	hasToolStart := false
+	for _, e := range events {
+		if e.Type == StreamEventText && e.Text == "Here is the result" {
+			hasText = true
+		}
+		if e.Type == StreamEventToolStart {
+			hasToolStart = true
+		}
+	}
+	if !hasText {
+		t.Error("Expected text event for content")
+	}
+	if !hasToolStart {
+		t.Error("Expected tool_start event")
+	}
+}
+
+func TestMockToolStreamingProvider_NoTools(t *testing.T) {
+	// No tools — returns text response with text event
+	provider := NewMockToolStreamingProvider()
+	var events []StreamEvent
+	callback := func(e StreamEvent) { events = append(events, e) }
+
+	resp, err := provider.StreamWithTools(context.Background(), nil, 0.5, nil, callback)
+	if err != nil {
+		t.Fatalf("StreamWithTools failed: %v", err)
+	}
+	if resp.Content == "" {
+		t.Error("Expected text content when no tools")
+	}
+	hasText := false
+	for _, e := range events {
+		if e.Type == StreamEventText {
+			hasText = true
+		}
+	}
+	if !hasText {
+		t.Error("Expected text event when no tools provided")
+	}
+}
+
+func TestMockToolStreamingProvider_ContextCancellation(t *testing.T) {
+	t.Run("before_call", func(t *testing.T) {
+		provider := NewMockToolStreamingProvider()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		tools := []Tool{{Name: "search"}}
+		_, err := provider.StreamWithTools(ctx, nil, 0.5, tools, func(_ StreamEvent) {})
+		if err == nil {
+			t.Error("Expected context cancellation error")
+		}
+	})
+
+	t.Run("cancel_before_text", func(t *testing.T) {
+		// Context already canceled when text emission happens
+		provider := NewMockToolStreamingProvider()
+		provider.WithToolResponse(func(_ []Message, _ []Tool) *ProviderResponse {
+			return &ProviderResponse{
+				Content:    "some text",
+				StopReason: StopReasonEndTurn,
+				Usage:      TokenUsage{Prompt: 10, Completion: 5, Total: 15},
+			}
+		})
+
+		// CallWithTools doesn't check ctx, so cancel after construction but it will
+		// be detected at the select before text emission
+		ctx, cancel := context.WithCancel(context.Background())
+		// We need ctx canceled before the select runs. Use a callback that wraps
+		// a provider returning content. Cancel ctx right before calling StreamWithTools
+		// won't work because CallWithTools still succeeds.
+		// Instead, wrap with a provider that cancels ctx during CallWithTools:
+		cancel()
+		_, err := provider.StreamWithTools(ctx, nil, 0.5, nil, func(_ StreamEvent) {})
+		// CallWithTools on unavailable=true provider succeeds, but ctx is done
+		// so the select before text emission should catch it
+		if err == nil {
+			t.Error("Expected context cancellation error")
+		}
+	})
+
+	t.Run("cancel_before_tool_loop", func(t *testing.T) {
+		// Cancel in the text callback so tool loop hits ctx.Done
+		provider := NewMockToolStreamingProvider()
+		provider.WithToolResponse(func(_ []Message, _ []Tool) *ProviderResponse {
+			return &ProviderResponse{
+				Content:    "text first",
+				StopReason: StopReasonToolUse,
+				ToolCalls:  []ToolCall{{ID: "call_1", Name: "search", Input: json.RawMessage(`{}`)}},
+				Usage:      TokenUsage{Prompt: 10, Completion: 5, Total: 15},
+			}
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var events []StreamEvent
+		callback := func(e StreamEvent) {
+			events = append(events, e)
+			cancel() // Cancel after first event (text), tool loop should see ctx.Done
+		}
+
+		_, err := provider.StreamWithTools(ctx, nil, 0.5, []Tool{{Name: "search"}}, callback)
+		if err == nil {
+			t.Error("Expected context cancellation error after callback cancels")
+		}
+		if len(events) == 0 {
+			t.Error("Expected at least one event before cancellation")
+		}
+	})
 }
 
 func TestMockProviderFixed_Name(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -50,10 +50,16 @@ func NewTerminal(provider Provider) pipz.Chainable[*SynapseRequest] {
 		}
 
 		// Route to the appropriate provider method based on request capabilities.
-		// Tools take priority when present. Streaming without tools uses the stream path.
+		// Priority: tools+streaming → tools → text streaming → standard call.
 		var resp *ProviderResponse
 		var err error
-		if len(req.Tools) > 0 {
+		if len(req.Tools) > 0 && req.StreamEventCallback != nil {
+			tsp, ok := provider.(ToolStreamingProvider)
+			if !ok {
+				return req, fmt.Errorf("provider %s does not support streaming with tools", provider.Name())
+			}
+			resp, err = tsp.StreamWithTools(ctx, messages, req.Temperature, req.Tools, req.StreamEventCallback)
+		} else if len(req.Tools) > 0 {
 			tp, ok := provider.(ToolProvider)
 			if !ok {
 				return req, fmt.Errorf("provider %s does not support tools", provider.Name())

--- a/service_test.go
+++ b/service_test.go
@@ -259,6 +259,72 @@ func (m *mockFixedStreamingProvider) Stream(ctx context.Context, messages []Mess
 	return resp, nil
 }
 
+func TestNewTerminal_ToolStreamingRouting(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		// ToolStreamingProvider routes through StreamWithTools
+		provider := NewMockToolStreamingProvider()
+		terminal := NewTerminal(provider)
+
+		var events []StreamEvent
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Prompt:      &Prompt{Task: "test", Input: "test", Schema: "{}"},
+			Temperature: 0.5,
+			Tools:       []Tool{{Name: "search"}},
+			StreamEventCallback: func(e StreamEvent) {
+				events = append(events, e)
+			},
+		}
+		_, err := terminal.Process(ctx, req)
+		if err != nil {
+			t.Fatalf("Process failed: %v", err)
+		}
+		if len(events) == 0 {
+			t.Error("Expected stream events from tool streaming provider")
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Non-tool-streaming provider errors when tools+stream event callback
+		provider := NewMockToolProvider() // ToolProvider but not ToolStreamingProvider
+		terminal := NewTerminal(provider)
+
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Prompt:      &Prompt{Task: "test", Input: "test", Schema: "{}"},
+			Temperature: 0.5,
+			Tools:       []Tool{{Name: "search"}},
+			StreamEventCallback: func(_ StreamEvent) {},
+		}
+		_, err := terminal.Process(ctx, req)
+		if err == nil {
+			t.Error("Expected error when ToolProvider lacks ToolStreamingProvider")
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		// Tools without StreamEventCallback routes to CallWithTools (not streaming)
+		provider := NewMockToolStreamingProvider()
+		terminal := NewTerminal(provider)
+
+		var events []StreamEvent
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Prompt:      &Prompt{Task: "test", Input: "test", Schema: "{}"},
+			Temperature: 0.5,
+			Tools:       []Tool{{Name: "search"}},
+			// No StreamEventCallback — should use CallWithTools
+		}
+		_, err := terminal.Process(ctx, req)
+		if err != nil {
+			t.Fatalf("Process failed: %v", err)
+		}
+		if len(events) != 0 {
+			t.Error("Should not have streamed without StreamEventCallback")
+		}
+	})
+}
+
 func TestNewTerminal_ToolRouting(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		// ToolProvider routes through CallWithTools when tools present

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -474,3 +474,74 @@ func (r *StreamRecorder) Reset() {
 	defer r.mu.Unlock()
 	r.chunks = make([]string, 0)
 }
+
+// StreamEventRecorder records typed stream events for test assertions.
+type StreamEventRecorder struct {
+	events []zyn.StreamEvent
+	mu     sync.Mutex
+}
+
+// NewStreamEventRecorder creates a new StreamEventRecorder.
+func NewStreamEventRecorder() *StreamEventRecorder {
+	return &StreamEventRecorder{
+		events: make([]zyn.StreamEvent, 0),
+	}
+}
+
+// Callback returns a StreamEventCallback that records events.
+func (r *StreamEventRecorder) Callback() zyn.StreamEventCallback {
+	return func(event zyn.StreamEvent) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.events = append(r.events, event)
+	}
+}
+
+// Events returns a copy of all recorded events.
+func (r *StreamEventRecorder) Events() []zyn.StreamEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	events := make([]zyn.StreamEvent, len(r.events))
+	copy(events, r.events)
+	return events
+}
+
+// EventCount returns the number of events recorded.
+func (r *StreamEventRecorder) EventCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+// TextEvents returns only text events.
+func (r *StreamEventRecorder) TextEvents() []zyn.StreamEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var texts []zyn.StreamEvent
+	for _, e := range r.events {
+		if e.Type == zyn.StreamEventText {
+			texts = append(texts, e)
+		}
+	}
+	return texts
+}
+
+// ToolStartEvents returns only tool_start events.
+func (r *StreamEventRecorder) ToolStartEvents() []zyn.StreamEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var starts []zyn.StreamEvent
+	for _, e := range r.events {
+		if e.Type == zyn.StreamEventToolStart {
+			starts = append(starts, e)
+		}
+	}
+	return starts
+}
+
+// Reset clears all recorded events.
+func (r *StreamEventRecorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = make([]zyn.StreamEvent, 0)
+}

--- a/testing/helpers_test.go
+++ b/testing/helpers_test.go
@@ -633,6 +633,59 @@ func TestStreamRecorder_ChunksReturnsCopy(t *testing.T) {
 	}
 }
 
+func TestStreamEventRecorder(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		recorder := NewStreamEventRecorder()
+		if recorder.EventCount() != 0 {
+			t.Error("New recorder should have 0 events")
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		recorder := NewStreamEventRecorder()
+		cb := recorder.Callback()
+		cb(zyn.StreamEvent{Type: zyn.StreamEventText, Text: "hello"})
+		cb(zyn.StreamEvent{Type: zyn.StreamEventToolStart, ToolCall: &zyn.ToolCall{ID: "1", Name: "search"}, Index: 0})
+		cb(zyn.StreamEvent{Type: zyn.StreamEventToolEnd, Index: 0})
+
+		if recorder.EventCount() != 3 {
+			t.Errorf("Expected 3 events, got %d", recorder.EventCount())
+		}
+		texts := recorder.TextEvents()
+		if len(texts) != 1 || texts[0].Text != "hello" {
+			t.Errorf("Unexpected text events: %v", texts)
+		}
+		starts := recorder.ToolStartEvents()
+		if len(starts) != 1 || starts[0].ToolCall.Name != "search" {
+			t.Errorf("Unexpected tool start events: %v", starts)
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		recorder := NewStreamEventRecorder()
+		cb := recorder.Callback()
+		cb(zyn.StreamEvent{Type: zyn.StreamEventText, Text: "a"})
+		recorder.Reset()
+		if recorder.EventCount() != 0 {
+			t.Error("Reset should clear events")
+		}
+	})
+}
+
+func TestStreamEventRecorder_EventsCopy(t *testing.T) {
+	recorder := NewStreamEventRecorder()
+	cb := recorder.Callback()
+	cb(zyn.StreamEvent{Type: zyn.StreamEventText, Text: "a"})
+
+	events := recorder.Events()
+	events[0].Text = "modified"
+
+	original := recorder.Events()
+	if original[0].Text != "a" {
+		t.Error("Events() should return a copy")
+	}
+}
+
 func TestSequencedProvider_EmptyResponses(t *testing.T) {
 	// Test with no responses - should use default error response
 	provider := NewSequencedProvider()


### PR DESCRIPTION
## Summary

- Add `ToolStreamingProvider` interface with `StreamWithTools` for streaming tool-aware responses
- Terminal routing complete: tools+event callback → StreamWithTools → CallWithTools → Stream → Call
- `StreamEventRecorder` test helper with event filtering

## Changes

**api.go** — `ToolStreamingProvider` interface, `StreamEventCallback` field on `SynapseRequest`

**service.go** — Terminal routing: tools + event callback takes highest priority, then tools-only, then text streaming, then standard Call

**mock.go** — `MockToolStreamingProvider` emits tool_start/tool_delta/tool_end events per tool call

**testing/helpers.go** — `StreamEventRecorder` with `Callback()`, `Events()`, `TextEvents()`, `ToolStartEvents()`, `Reset()`

## Test Plan

- Terminal routing: tool streaming routes correctly, non-streaming-tool provider errors, tools without event callback falls through
- MockToolStreamingProvider: events emitted, nil callback, context cancellation
- StreamEventRecorder: record, filter, reset, copy safety
- Interface satisfaction tests
- All existing tests pass: `go test -race ./...`
- `golangci-lint run ./...` clean

## Phase Context

Final phase (4 of 4) for #13. All four phases:
1. Core types (Tool, ToolCall, StreamEvent) — merged in #14
2. ToolProvider interface + terminal routing — merged in #15
3. OpenAI provider implementation — merged in #16
4. **This PR:** Streaming with tools

Closes #13