### PR TITLE
feat: ToolLoop synapse for multi-turn tool execution

### DIFF
--- a/api.go
+++ b/api.go
@@ -168,7 +168,9 @@ type SynapseRequest struct {
 	ProviderName string // Name of the provider being used
 
 	// Output fields (populated by pipeline)
-	Response string      // Raw text response from provider
-	Usage    *TokenUsage // Token usage from provider response
-	Error    error       // Any error that occurred during processing
+	Response      string      // Raw text response from provider
+	Usage         *TokenUsage // Token usage from provider response
+	Error         error       // Any error that occurred during processing
+	StopReason    string      // Stop reason from provider response (populated by raw terminal)
+	ResponseCalls []ToolCall  // Tool calls from provider response (populated by raw terminal)
 }

--- a/hooks.go
+++ b/hooks.go
@@ -11,6 +11,8 @@ var (
 	ProviderCallCompleted = capitan.NewSignal("llm.provider.call.completed", "LLM provider HTTP call succeeded with token usage and timing metrics")
 	ProviderCallFailed    = capitan.NewSignal("llm.provider.call.failed", "LLM provider HTTP call failed with status code and API error details")
 	ResponseParseFailed   = capitan.NewSignal("llm.response.failed", "LLM response parsing failed with validation or JSON decode error")
+	ToolLoopIteration     = capitan.NewSignal("llm.toolloop.iteration", "Tool loop iteration completed with provider response")
+	ToolLoopDispatch      = capitan.NewSignal("llm.toolloop.dispatch", "Tool dispatched to handler within a loop iteration")
 )
 
 // Keys for hook event fields.
@@ -51,4 +53,11 @@ var (
 	ResponseIDKey           = capitan.NewStringKey("llm.response.id")
 	ResponseFinishReasonKey = capitan.NewStringKey("llm.response.finish.reason")
 	ResponseCreatedKey      = capitan.NewIntKey("llm.response.created")
+
+	// Tool loop metadata.
+	IterationKey     = capitan.NewIntKey("llm.toolloop.iteration")
+	ToolNameKey      = capitan.NewStringKey("llm.toolloop.tool.name")
+	ToolCallIDKey    = capitan.NewStringKey("llm.toolloop.tool.call.id")
+	CompletedKey     = capitan.NewStringKey("llm.toolloop.completed")
+	MaxIterationsKey = capitan.NewIntKey("llm.toolloop.max_iterations")
 )

--- a/service.go
+++ b/service.go
@@ -79,6 +79,50 @@ func NewTerminal(provider Provider) pipz.Chainable[*SynapseRequest] {
 	})
 }
 
+// Identity for the raw terminal processor.
+var rawTerminalID = pipz.NewIdentity("zyn:raw-terminal", "LLM provider raw terminal")
+
+// NewRawTerminal creates a terminal processor that passes messages through as-is.
+// Unlike NewTerminal, it does not append a rendered Prompt as a user message.
+// It also populates StopReason and ResponseCalls on the request for loop consumers.
+// Used by ToolLoopSynapse where messages are built by the loop, not by a Prompt.
+func NewRawTerminal(provider Provider) pipz.Chainable[*SynapseRequest] {
+	return pipz.Apply(rawTerminalID, func(ctx context.Context, req *SynapseRequest) (*SynapseRequest, error) {
+		// Use req.Messages as-is — no prompt appending
+		messages := req.Messages
+
+		// Same routing logic as NewTerminal
+		var resp *ProviderResponse
+		var err error
+		if len(req.Tools) > 0 && req.StreamEventCallback != nil {
+			tsp, ok := provider.(ToolStreamingProvider)
+			if !ok {
+				return req, fmt.Errorf("provider %s does not support streaming with tools", provider.Name())
+			}
+			resp, err = tsp.StreamWithTools(ctx, messages, req.Temperature, req.Tools, req.StreamEventCallback)
+		} else if len(req.Tools) > 0 {
+			tp, ok := provider.(ToolProvider)
+			if !ok {
+				return req, fmt.Errorf("provider %s does not support tools", provider.Name())
+			}
+			resp, err = tp.CallWithTools(ctx, messages, req.Temperature, req.Tools)
+		} else if sp, ok := provider.(StreamingProvider); ok && req.StreamCallback != nil {
+			resp, err = sp.Stream(ctx, messages, req.Temperature, req.StreamCallback)
+		} else {
+			resp, err = provider.Call(ctx, messages, req.Temperature)
+		}
+		if err != nil {
+			return req, err
+		}
+
+		req.Response = resp.Content
+		req.Usage = &resp.Usage
+		req.StopReason = resp.StopReason
+		req.ResponseCalls = resp.ToolCalls
+		return req, nil
+	})
+}
+
 // GetPipeline returns the internal pipeline for composition.
 // This is used by WithFallback to combine pipelines.
 func (s *Service[T]) GetPipeline() pipz.Chainable[*SynapseRequest] {

--- a/service_test.go
+++ b/service_test.go
@@ -259,6 +259,116 @@ func (m *mockFixedStreamingProvider) Stream(ctx context.Context, messages []Mess
 	return resp, nil
 }
 
+func TestNewRawTerminal(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		// Raw terminal uses messages as-is and populates StopReason/ResponseCalls
+		provider := NewMockToolProvider()
+		terminal := NewRawTerminal(provider)
+
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Messages:    []Message{{Role: RoleUser, Content: "test"}},
+			Temperature: 0.5,
+			Tools:       []Tool{{Name: "search"}},
+		}
+		processed, err := terminal.Process(ctx, req)
+		if err != nil {
+			t.Fatalf("Process failed: %v", err)
+		}
+		if processed.StopReason != StopReasonToolUse {
+			t.Errorf("Expected StopReason='tool_use', got '%s'", processed.StopReason)
+		}
+		if len(processed.ResponseCalls) != 1 {
+			t.Errorf("Expected 1 ResponseCall, got %d", len(processed.ResponseCalls))
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Non-tool provider with tools returns error
+		provider := NewMockProvider()
+		terminal := NewRawTerminal(provider)
+
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Messages:    []Message{{Role: RoleUser, Content: "test"}},
+			Temperature: 0.5,
+			Tools:       []Tool{{Name: "search"}},
+		}
+		_, err := terminal.Process(ctx, req)
+		if err == nil {
+			t.Error("Expected error when non-tool provider receives tools")
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		// No tools falls through to standard Call
+		provider := NewMockProviderWithResponse(`{"decision": true, "confidence": 0.9, "reasoning": ["test"]}`)
+		terminal := NewRawTerminal(provider)
+
+		ctx := context.Background()
+		req := &SynapseRequest{
+			Messages:    []Message{{Role: RoleUser, Content: "test"}},
+			Temperature: 0.5,
+		}
+		processed, err := terminal.Process(ctx, req)
+		if err != nil {
+			t.Fatalf("Process failed: %v", err)
+		}
+		if processed.Response == "" {
+			t.Error("Expected non-empty response from standard Call path")
+		}
+	})
+}
+
+func TestNewRawTerminal_StreamingWithTools(t *testing.T) {
+	t.Run("routes_to_stream_with_tools", func(t *testing.T) {
+		provider := NewMockToolStreamingProvider()
+		provider.WithToolResponse(func(_ []Message, _ []Tool) *ProviderResponse {
+			return &ProviderResponse{
+				Content:    "streamed",
+				StopReason: StopReasonEndTurn,
+				Usage:      TokenUsage{Prompt: 10, Completion: 5, Total: 15},
+			}
+		})
+		terminal := NewRawTerminal(provider)
+
+		var events []StreamEvent
+		req := &SynapseRequest{
+			Messages:            []Message{{Role: RoleUser, Content: "test"}},
+			Temperature:         0.5,
+			Tools:               []Tool{{Name: "search"}},
+			StreamEventCallback: func(e StreamEvent) { events = append(events, e) },
+		}
+		processed, err := terminal.Process(context.Background(), req)
+		if err != nil {
+			t.Fatalf("Process failed: %v", err)
+		}
+		if processed.StopReason != StopReasonEndTurn {
+			t.Errorf("Expected StopReason='end_turn', got '%s'", processed.StopReason)
+		}
+		if len(events) == 0 {
+			t.Error("Expected stream events")
+		}
+	})
+
+	t.Run("error_without_tool_streaming", func(t *testing.T) {
+		// ToolProvider without ToolStreamingProvider errors on streaming+tools
+		provider := NewMockToolProvider()
+		terminal := NewRawTerminal(provider)
+
+		req := &SynapseRequest{
+			Messages:            []Message{{Role: RoleUser, Content: "test"}},
+			Temperature:         0.5,
+			Tools:               []Tool{{Name: "search"}},
+			StreamEventCallback: func(_ StreamEvent) {},
+		}
+		_, err := terminal.Process(context.Background(), req)
+		if err == nil {
+			t.Error("Expected error when ToolProvider lacks ToolStreamingProvider")
+		}
+	})
+}
+
 func TestNewTerminal_ToolStreamingRouting(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		// ToolStreamingProvider routes through StreamWithTools

--- a/toolloop.go
+++ b/toolloop.go
@@ -1,0 +1,255 @@
+package zyn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/zoobz-io/capitan"
+	"github.com/zoobz-io/pipz"
+)
+
+// ToolHandler dispatches tool calls back to consumer code.
+// Intentionally compatible with ago.Executor.
+//
+// Execute error semantics:
+//   - Returns ("", err) → dispatch failure, loop stops, error propagated
+//   - Returns ("error: ...", nil) → tool error, sent as tool result, loop continues
+type ToolHandler interface {
+	ListTools() []Tool
+	Execute(ctx context.Context, call ToolCall) (string, error)
+}
+
+// ToolLoopResponse contains the result of a multi-turn tool execution loop.
+type ToolLoopResponse struct {
+	Content    string           `json:"content"`
+	Completed  bool             `json:"completed"`
+	Iterations int              `json:"iterations"`
+	Calls      []ToolCallRecord `json:"calls"`
+	Usage      TokenUsage       `json:"usage"`
+}
+
+// Validate checks that the response is valid.
+func (ToolLoopResponse) Validate() error {
+	return nil
+}
+
+// ToolCallRecord describes a single tool invocation within the loop.
+type ToolCallRecord struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	Output    string          `json:"output"`
+	Error     bool            `json:"error"`
+	Iteration int             `json:"iteration"`
+}
+
+// ToolLoopSynapse wraps a multi-turn tool execution loop with reliability,
+// session management, and signal emission. Each provider call within the loop
+// runs through a pipz pipeline with the configured options.
+type ToolLoopSynapse struct {
+	handler       ToolHandler
+	pipeline      pipz.Chainable[*SynapseRequest]
+	providerName  string
+	maxIterations int
+	temperature   float32
+}
+
+// ToolLoop creates a new tool loop synapse.
+// The provider must implement ToolProvider.
+// Options (retry, timeout, circuit breaker, etc.) apply per provider call, not per loop.
+func ToolLoop(handler ToolHandler, provider Provider, opts ...Option) (*ToolLoopSynapse, error) {
+	if handler == nil {
+		return nil, fmt.Errorf("tool handler is required")
+	}
+	if _, ok := provider.(ToolProvider); !ok {
+		return nil, fmt.Errorf("provider %s does not implement ToolProvider", provider.Name())
+	}
+
+	pipeline := NewRawTerminal(provider)
+	for _, opt := range opts {
+		pipeline = opt(pipeline)
+	}
+
+	return &ToolLoopSynapse{
+		handler:       handler,
+		pipeline:      pipeline,
+		providerName:  provider.Name(),
+		maxIterations: 10,
+		temperature:   DefaultTemperatureDeterministic,
+	}, nil
+}
+
+// WithMaxIterations sets the maximum number of loop iterations.
+// Each iteration is one provider call. Default is 10.
+func (t *ToolLoopSynapse) WithMaxIterations(n int) *ToolLoopSynapse {
+	t.maxIterations = n
+	return t
+}
+
+// GetPipeline returns the underlying pipeline. Implements ServiceProvider.
+func (t *ToolLoopSynapse) GetPipeline() pipz.Chainable[*SynapseRequest] {
+	return t.pipeline
+}
+
+// Fire runs the tool loop and returns the final text content.
+func (t *ToolLoopSynapse) Fire(ctx context.Context, session *Session, input string) (string, error) {
+	resp, err := t.fireLoop(ctx, session, input, nil)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+// FireWithDetails runs the tool loop and returns the full response with call records.
+func (t *ToolLoopSynapse) FireWithDetails(ctx context.Context, session *Session, input string) (*ToolLoopResponse, error) {
+	return t.fireLoop(ctx, session, input, nil)
+}
+
+// FireStream runs the tool loop with streaming, delivering typed events per call.
+// If the provider implements ToolStreamingProvider, each call streams via the callback.
+func (t *ToolLoopSynapse) FireStream(ctx context.Context, session *Session, input string, callback StreamEventCallback) (string, error) {
+	resp, err := t.fireLoop(ctx, session, input, callback)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+func (t *ToolLoopSynapse) fireLoop(ctx context.Context, session *Session, input string, streamCallback StreamEventCallback) (*ToolLoopResponse, error) {
+	requestID := uuid.New().String()
+
+	capitan.Info(ctx, RequestStarted,
+		RequestIDKey.Field(requestID),
+		SynapseTypeKey.Field("toolloop"),
+		ProviderKey.Field(t.providerName),
+		InputKey.Field(input),
+		TemperatureKey.Field(float64(t.temperature)),
+	)
+
+	tools := t.handler.ListTools()
+
+	// Build initial messages: session history + user input
+	sessionMessages := session.Messages()
+	messages := make([]Message, len(sessionMessages), len(sessionMessages)+1)
+	copy(messages, sessionMessages)
+	messages = append(messages, Message{
+		Role:    RoleUser,
+		Content: input,
+	})
+
+	var allRecords []ToolCallRecord
+	var aggregatedUsage TokenUsage
+	var finalContent string
+	completed := false
+	iterationCount := 0
+
+	for iteration := 1; iteration <= t.maxIterations; iteration++ {
+		iterationCount = iteration
+
+		req := &SynapseRequest{
+			Messages:            messages,
+			Temperature:         t.temperature,
+			Tools:               tools,
+			StreamEventCallback: streamCallback,
+			SessionID:           session.ID(),
+			RequestID:           requestID,
+			SynapseType:         "toolloop",
+			ProviderName:        t.providerName,
+		}
+
+		processed, err := t.pipeline.Process(ctx, req)
+		if err != nil {
+			capitan.Error(ctx, RequestFailed,
+				RequestIDKey.Field(requestID),
+				SynapseTypeKey.Field("toolloop"),
+				ProviderKey.Field(t.providerName),
+				ErrorKey.Field(err.Error()),
+			)
+			return nil, err
+		}
+
+		// Aggregate usage
+		if processed.Usage != nil {
+			aggregatedUsage.Prompt += processed.Usage.Prompt
+			aggregatedUsage.Completion += processed.Usage.Completion
+			aggregatedUsage.Total += processed.Usage.Total
+		}
+
+		capitan.Info(ctx, ToolLoopIteration,
+			RequestIDKey.Field(requestID),
+			IterationKey.Field(iteration),
+			ResponseFinishReasonKey.Field(processed.StopReason),
+		)
+
+		// Not a tool call — done
+		if processed.StopReason != StopReasonToolUse {
+			finalContent = processed.Response
+			completed = true
+			break
+		}
+
+		// Append assistant message with tool calls
+		messages = append(messages, Message{
+			Role:      RoleAssistant,
+			Content:   processed.Response,
+			ToolCalls: processed.ResponseCalls,
+		})
+
+		// Execute each tool call
+		for _, tc := range processed.ResponseCalls {
+			capitan.Info(ctx, ToolLoopDispatch,
+				RequestIDKey.Field(requestID),
+				IterationKey.Field(iteration),
+				ToolNameKey.Field(tc.Name),
+				ToolCallIDKey.Field(tc.ID),
+			)
+
+			output, execErr := t.handler.Execute(ctx, tc)
+			if execErr != nil {
+				capitan.Error(ctx, RequestFailed,
+					RequestIDKey.Field(requestID),
+					SynapseTypeKey.Field("toolloop"),
+					ProviderKey.Field(t.providerName),
+					ErrorKey.Field(execErr.Error()),
+					ToolNameKey.Field(tc.Name),
+				)
+				return nil, fmt.Errorf("tool %s dispatch failed: %w", tc.Name, execErr)
+			}
+
+			allRecords = append(allRecords, ToolCallRecord{
+				ID:        tc.ID,
+				Name:      tc.Name,
+				Input:     tc.Input,
+				Output:    output,
+				Iteration: iteration,
+			})
+
+			messages = append(messages, Message{
+				Role:       RoleTool,
+				Content:    output,
+				ToolCallID: tc.ID,
+			})
+		}
+	}
+
+	// Update session transactionally with full conversation
+	session.SetMessages(messages)
+	session.SetUsage(&aggregatedUsage)
+
+	capitan.Info(ctx, RequestCompleted,
+		RequestIDKey.Field(requestID),
+		SynapseTypeKey.Field("toolloop"),
+		ProviderKey.Field(t.providerName),
+		OutputKey.Field(finalContent),
+	)
+
+	return &ToolLoopResponse{
+		Content:    finalContent,
+		Completed:  completed,
+		Iterations: iterationCount,
+		Calls:      allRecords,
+		Usage:      aggregatedUsage,
+	}, nil
+}

--- a/toolloop_test.go
+++ b/toolloop_test.go
@@ -1,0 +1,392 @@
+package zyn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// mockToolHandler is a test-local ToolHandler implementation.
+type mockToolHandler struct {
+	tools    []Tool
+	execFunc func(ctx context.Context, call ToolCall) (string, error)
+}
+
+func newMockToolHandler(tools []Tool) *mockToolHandler {
+	return &mockToolHandler{
+		tools: tools,
+		execFunc: func(_ context.Context, call ToolCall) (string, error) {
+			return fmt.Sprintf("result for %s", call.Name), nil
+		},
+	}
+}
+
+func (m *mockToolHandler) ListTools() []Tool { return m.tools }
+
+func (m *mockToolHandler) Execute(ctx context.Context, call ToolCall) (string, error) {
+	return m.execFunc(ctx, call)
+}
+
+func (m *mockToolHandler) withExecFunc(fn func(context.Context, ToolCall) (string, error)) *mockToolHandler {
+	m.execFunc = fn
+	return m
+}
+
+// multiTurnProvider returns tool_use for the first N calls, then end_turn.
+func multiTurnProvider(toolUseCount int) *MockToolProvider {
+	callCount := 0
+	return NewMockToolProvider().WithToolResponse(func(_ []Message, tools []Tool) *ProviderResponse {
+		callCount++
+		if callCount <= toolUseCount {
+			toolName := "search"
+			if len(tools) > 0 {
+				toolName = tools[0].Name
+			}
+			return &ProviderResponse{
+				StopReason: StopReasonToolUse,
+				ToolCalls: []ToolCall{{
+					ID:    fmt.Sprintf("call_%d", callCount),
+					Name:  toolName,
+					Input: json.RawMessage(`{}`),
+				}},
+				Usage: TokenUsage{Prompt: 100, Completion: 50, Total: 150},
+			}
+		}
+		return &ProviderResponse{
+			Content:    "final answer",
+			StopReason: StopReasonEndTurn,
+			Usage:      TokenUsage{Prompt: 100, Completion: 50, Total: 150},
+		}
+	})
+}
+
+func TestToolLoop(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		provider := NewMockToolProvider()
+		synapse, err := ToolLoop(handler, provider)
+		if err != nil {
+			t.Fatalf("ToolLoop creation failed: %v", err)
+		}
+		if synapse == nil {
+			t.Fatal("ToolLoop returned nil")
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Nil handler
+		_, err := ToolLoop(nil, NewMockToolProvider())
+		if err == nil {
+			t.Error("Expected error with nil handler")
+		}
+
+		// Non-ToolProvider
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		_, err = ToolLoop(handler, NewMockProvider())
+		if err == nil {
+			t.Error("Expected error with non-ToolProvider")
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		provider := NewMockToolProvider()
+		synapse, err := ToolLoop(handler, provider,
+			WithRetry(3),
+			WithTimeout(10*time.Second))
+		if err != nil {
+			t.Fatalf("ToolLoop with options failed: %v", err)
+		}
+		if synapse.GetPipeline() == nil {
+			t.Error("GetPipeline returned nil")
+		}
+	})
+}
+
+func TestToolLoopSynapse_Fire(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		// Single iteration — provider returns end_turn immediately
+		provider := multiTurnProvider(0)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		result, err := synapse.Fire(context.Background(), NewSession(), "hello")
+		if err != nil {
+			t.Fatalf("Fire failed: %v", err)
+		}
+		if result != "final answer" {
+			t.Errorf("Expected 'final answer', got '%s'", result)
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Multi-turn: 2 tool_use iterations then end_turn
+		provider := multiTurnProvider(2)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		session := NewSession()
+		result, err := synapse.Fire(context.Background(), session, "search for something")
+		if err != nil {
+			t.Fatalf("Fire failed: %v", err)
+		}
+		if result != "final answer" {
+			t.Errorf("Expected 'final answer', got '%s'", result)
+		}
+		// Session should have messages (user + assistant/tool pairs + final assistant)
+		if session.Len() == 0 {
+			t.Error("Expected session to have messages after loop")
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		// Max iterations hit — Completed should be false
+		provider := multiTurnProvider(100) // Always returns tool_use
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+		synapse.WithMaxIterations(3)
+
+		resp, err := synapse.FireWithDetails(context.Background(), NewSession(), "loop forever")
+		if err != nil {
+			t.Fatalf("FireWithDetails failed: %v", err)
+		}
+		if resp.Completed {
+			t.Error("Expected Completed=false when max iterations hit")
+		}
+		if resp.Iterations != 3 {
+			t.Errorf("Expected 3 iterations, got %d", resp.Iterations)
+		}
+	})
+}
+
+func TestToolLoopSynapse_FireWithDetails(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		provider := multiTurnProvider(1)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		resp, err := synapse.FireWithDetails(context.Background(), NewSession(), "test")
+		if err != nil {
+			t.Fatalf("FireWithDetails failed: %v", err)
+		}
+		if resp.Content != "final answer" {
+			t.Errorf("Expected content 'final answer', got '%s'", resp.Content)
+		}
+		if !resp.Completed {
+			t.Error("Expected Completed=true")
+		}
+		if resp.Iterations != 2 {
+			t.Errorf("Expected 2 iterations (1 tool_use + 1 end_turn), got %d", resp.Iterations)
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Verify aggregated usage
+		provider := multiTurnProvider(2)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		resp, err := synapse.FireWithDetails(context.Background(), NewSession(), "test")
+		if err != nil {
+			t.Fatalf("FireWithDetails failed: %v", err)
+		}
+		// 3 iterations × 150 total tokens each
+		if resp.Usage.Total != 450 {
+			t.Errorf("Expected aggregated Total=450, got %d", resp.Usage.Total)
+		}
+	})
+
+	t.Run("chaining", func(t *testing.T) {
+		// Verify ToolCallRecords
+		provider := multiTurnProvider(2)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		resp, err := synapse.FireWithDetails(context.Background(), NewSession(), "test")
+		if err != nil {
+			t.Fatalf("FireWithDetails failed: %v", err)
+		}
+		if len(resp.Calls) != 2 {
+			t.Fatalf("Expected 2 call records, got %d", len(resp.Calls))
+		}
+		if resp.Calls[0].Name != "search" {
+			t.Errorf("Expected call name 'search', got '%s'", resp.Calls[0].Name)
+		}
+		if resp.Calls[0].Output != "result for search" {
+			t.Errorf("Expected output 'result for search', got '%s'", resp.Calls[0].Output)
+		}
+		if resp.Calls[0].Iteration != 1 {
+			t.Errorf("Expected iteration 1, got %d", resp.Calls[0].Iteration)
+		}
+		if resp.Calls[1].Iteration != 2 {
+			t.Errorf("Expected iteration 2, got %d", resp.Calls[1].Iteration)
+		}
+	})
+}
+
+func TestToolLoopSynapse_FireStream(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		// Use a streaming provider that returns end_turn with content
+		provider := NewMockToolStreamingProvider()
+		provider.WithToolResponse(func(_ []Message, _ []Tool) *ProviderResponse {
+			return &ProviderResponse{
+				Content:    "streamed answer",
+				StopReason: StopReasonEndTurn,
+				Usage:      TokenUsage{Prompt: 100, Completion: 50, Total: 150},
+			}
+		})
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, err := ToolLoop(handler, provider)
+		if err != nil {
+			t.Fatalf("ToolLoop creation failed: %v", err)
+		}
+
+		var events []StreamEvent
+		callback := func(e StreamEvent) { events = append(events, e) }
+
+		result, err := synapse.FireStream(context.Background(), NewSession(), "test", callback)
+		if err != nil {
+			t.Fatalf("FireStream failed: %v", err)
+		}
+		if result != "streamed answer" {
+			t.Errorf("Expected 'streamed answer', got '%s'", result)
+		}
+		if len(events) == 0 {
+			t.Error("Expected stream events")
+		}
+	})
+
+	t.Run("reliability", func(t *testing.T) {
+		// Nil callback — falls back to non-streaming tool call
+		provider := multiTurnProvider(1)
+		handler := newMockToolHandler([]Tool{{Name: "search"}})
+		synapse, _ := ToolLoop(handler, provider)
+
+		result, err := synapse.FireStream(context.Background(), NewSession(), "test", nil)
+		if err != nil {
+			t.Fatalf("FireStream with nil callback failed: %v", err)
+		}
+		if result != "final answer" {
+			t.Errorf("Expected 'final answer', got '%s'", result)
+		}
+	})
+}
+
+func TestToolLoopSynapse_FireStream_Error(t *testing.T) {
+	provider := NewMockToolProvider()
+	provider.SetAvailable(false)
+	handler := newMockToolHandler([]Tool{{Name: "search"}})
+	synapse, _ := ToolLoop(handler, provider)
+
+	_, err := synapse.FireStream(context.Background(), NewSession(), "test", func(_ StreamEvent) {})
+	if err == nil {
+		t.Error("Expected error from unavailable provider")
+	}
+}
+
+func TestToolLoopSynapse_HandlerError(t *testing.T) {
+	t.Run("dispatch_failure", func(t *testing.T) {
+		provider := multiTurnProvider(1)
+		handler := newMockToolHandler([]Tool{{Name: "search"}}).
+			withExecFunc(func(_ context.Context, _ ToolCall) (string, error) {
+				return "", fmt.Errorf("tool not found")
+			})
+		synapse, _ := ToolLoop(handler, provider)
+
+		_, err := synapse.Fire(context.Background(), NewSession(), "test")
+		if err == nil {
+			t.Error("Expected error from handler dispatch failure")
+		}
+	})
+
+	t.Run("tool_error_continues", func(t *testing.T) {
+		// Tool returns error content (not dispatch error) — loop continues
+		provider := multiTurnProvider(1)
+		handler := newMockToolHandler([]Tool{{Name: "search"}}).
+			withExecFunc(func(_ context.Context, _ ToolCall) (string, error) {
+				return "error: invalid input", nil
+			})
+		synapse, _ := ToolLoop(handler, provider)
+
+		result, err := synapse.Fire(context.Background(), NewSession(), "test")
+		if err != nil {
+			t.Fatalf("Fire should not fail on tool error content: %v", err)
+		}
+		if result != "final answer" {
+			t.Errorf("Expected 'final answer', got '%s'", result)
+		}
+	})
+}
+
+func TestToolLoopSynapse_SessionUpdate(t *testing.T) {
+	provider := multiTurnProvider(1)
+	handler := newMockToolHandler([]Tool{{Name: "search"}})
+	synapse, _ := ToolLoop(handler, provider)
+
+	session := NewSession()
+	_, err := synapse.Fire(context.Background(), session, "test input")
+	if err != nil {
+		t.Fatalf("Fire failed: %v", err)
+	}
+
+	msgs := session.Messages()
+	if len(msgs) == 0 {
+		t.Fatal("Expected messages in session")
+	}
+	// First message should be user input
+	if msgs[0].Role != RoleUser || msgs[0].Content != "test input" {
+		t.Errorf("Expected first message to be user input, got role=%s content=%s", msgs[0].Role, msgs[0].Content)
+	}
+	// Should have assistant message with tool calls
+	hasAssistantToolCall := false
+	hasToolResult := false
+	for _, msg := range msgs {
+		if msg.Role == RoleAssistant && len(msg.ToolCalls) > 0 {
+			hasAssistantToolCall = true
+		}
+		if msg.Role == RoleTool {
+			hasToolResult = true
+		}
+	}
+	if !hasAssistantToolCall {
+		t.Error("Expected assistant message with tool calls in session")
+	}
+	if !hasToolResult {
+		t.Error("Expected tool result message in session")
+	}
+}
+
+func TestToolLoopSynapse_WithMaxIterations(t *testing.T) {
+	handler := newMockToolHandler([]Tool{{Name: "search"}})
+	synapse, _ := ToolLoop(handler, NewMockToolProvider())
+
+	result := synapse.WithMaxIterations(5)
+	if result != synapse {
+		t.Error("WithMaxIterations should return the same synapse for chaining")
+	}
+	if synapse.maxIterations != 5 {
+		t.Errorf("Expected maxIterations=5, got %d", synapse.maxIterations)
+	}
+}
+
+func TestToolLoopSynapse_GetPipeline(t *testing.T) {
+	handler := newMockToolHandler([]Tool{{Name: "search"}})
+	synapse, _ := ToolLoop(handler, NewMockToolProvider())
+
+	pipeline := synapse.GetPipeline()
+	if pipeline == nil {
+		t.Error("GetPipeline returned nil")
+	}
+
+	// Implements ServiceProvider
+	var _ ServiceProvider = synapse
+}
+
+func TestToolLoopResponse_Validate(t *testing.T) {
+	resp := ToolLoopResponse{}
+	if err := resp.Validate(); err != nil {
+		t.Errorf("ToolLoopResponse.Validate should not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ToolLoopSynapse` that wraps multi-turn tool call/dispatch/result loops with pipz reliability, session management, and capitan signals
- `ToolHandler` interface compatible with ago's `ToolExecutor` — `ListTools()` + `Execute(ctx, ToolCall) (string, error)`
- Pipeline options (retry, timeout, circuit breaker) apply per provider call, not per loop

## Changes

**toolloop.go** (new) — `ToolHandler`, `ToolLoopSynapse`, `ToolLoopResponse`, `ToolCallRecord`. Constructor validates `ToolProvider`. Loop: build messages → process through pipeline → check `StopReason` → dispatch tools → repeat. Session updated transactionally via `SetMessages`.

**service.go** — `NewRawTerminal` passes messages as-is (no Prompt rendering), populates `StopReason`/`ResponseCalls` on `SynapseRequest` for loop consumers.

**api.go** — `StopReason` and `ResponseCalls` output fields on `SynapseRequest`.

**hooks.go** — `ToolLoopIteration` and `ToolLoopDispatch` signals with `IterationKey`, `ToolNameKey`, `ToolCallIDKey`.

## Test Plan

- Constructor: valid, nil handler, non-ToolProvider, with options
- Fire: single iteration, multi-turn (2 tool_use + end_turn), max iterations hit
- FireWithDetails: all response fields, aggregated usage, call records with iteration tracking
- FireStream: streaming events delivered, nil callback fallback, error path
- Handler errors: dispatch failure stops loop, content errors continue
- Session: full conversation with user/assistant/tool messages persisted
- NewRawTerminal: tool routing, streaming+tools routing, standard fallback
- `go test -race ./...` clean, `golangci-lint` clean, all new code 100% covered

Closes #18